### PR TITLE
Build the published bundle in CI and run it end to end

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -1,4 +1,5 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# Type-checks the source, builds the bundle that actually gets published, and
+# runs it end to end against stub APIs.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Build
@@ -9,22 +10,25 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+    - uses: actions/checkout@v7
+    - name: Use Node.js from .node-version
+      uses: actions/setup-node@v7
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version-file: .node-version
         cache: 'npm'
     - run: npm ci
-    - run: npm run build --if-present
+    - name: Type-check
+      run: npm run tsc
+    - name: Bundle
+      run: npm run bundle
+    - name: Smoke test
+      run: node scripts/smoke-test.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,11 @@ External integrations are the Slack Web API (`@slack/web-api`) for status/holida
 - `npm run bundle` — runs `tsup`, producing the real artifact: a minified CommonJS bundle at `dist/roulette.js`. This is what `bin`/`main` point to and what consumers actually execute.
 - `npm run upload` — bundles then `npm publish --access public`. Requires npm auth. Bump `version` in `package.json` first (see `PUBLISHING.md`).
 
-There is **no test suite and no linter** configured — don't go looking for one or assume a `test`/`lint` script exists. Verification before publishing is a clean `npm run build` (type-check) plus a successful `npm run bundle`. CI (`.github/workflows/build-node.yml`) only runs `npm ci` + `npm run build` on Node 20.x; Node is pinned to 20.11.0 (`.node-version`).
+- `npm run smoke` — bundles, then runs `scripts/smoke-test.mjs`: it executes `dist/roulette.js` against stub Slack and GitLab servers on loopback and asserts on the comment it posts (author excluded, holiday reviewers excluded, one maintainer plus one other developer named) and on the create/no-op/replace behaviour for an existing note. No credentials or network access needed. Because it drives the bundle over real HTTP, it catches runtime breakage from dependency bumps that `tsc` passes clean.
+
+There is **no unit-test framework and no linter** configured — don't go looking for one or assume a `test`/`lint` script exists. Verification before publishing is `npm run tsc` (type-check) plus `npm run smoke`. CI (`.github/workflows/build-node.yml`) runs all three on the Node version in `.node-version` (pinned to 20.11.0).
+
+Merging to `main` needs a pull request with a passing `build` check and one approving review, all enforced by repository rulesets. Dependency bumps are merged by hand; the point of the smoke test is that a green Build is enough to judge one on, without running the tool against real Slack and GitLab first.
 
 ## Runtime Configuration (environment variables)
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "npm run tsc",
     "tsc": "tsc -p tsconfig.json",
     "bundle": "tsup",
+    "smoke": "npm run bundle && node scripts/smoke-test.mjs",
     "upload": "npm run bundle && npm publish --access public"
   },
   "files": [

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+/**
+ * End-to-end smoke test for the bundled CLI (`dist/roulette.js`).
+ *
+ * Stub Slack and GitLab servers stand in for the real APIs, so this exercises
+ * the published artifact — HTTP calls, request shapes and comment body
+ * included — without credentials or network access. Run `npm run bundle` first.
+ */
+
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:http'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+const AUTHOR_USER_ID = 1
+const PROJECT_ID = '4242'
+const MERGE_REQUEST_IID = '7'
+
+const REVIEWERS = {
+    reviewers: [
+        { name: 'Ada Author', email: 'ada@example.com', userId: AUTHOR_USER_ID, slackUserId: 'U_ADA', roles: ['maintainer', 'contributor'] },
+        { name: 'Grace Onholiday', email: 'grace@example.com', userId: 2, slackUserId: 'U_GRACE', roles: ['maintainer'] },
+        { name: 'Linus Maintainer', email: 'linus@example.com', userId: 3, slackUserId: 'U_LINUS', roles: ['maintainer'] },
+        { name: 'Barbara Contributor', email: 'barbara@example.com', userId: 4, slackUserId: 'U_BARBARA', roles: ['contributor'] },
+    ],
+}
+
+const SLACK_MEMBERS = [
+    { id: 'U_ADA', profile: { status_emoji: '' } },
+    { id: 'U_GRACE', profile: { status_emoji: ':palm_tree:' } },
+    { id: 'U_LINUS', profile: { status_emoji: ':coffee:' } },
+    { id: 'U_BARBARA', profile: { status_emoji: '' } },
+]
+
+const notesPath = `/gitlab/api/v4/projects/${PROJECT_ID}/merge_requests/${MERGE_REQUEST_IID}/notes`
+
+/**
+ * @param {object[]} existingNotes notes the stub GitLab returns from the GET
+ * @returns {Promise<{requests: {method: string, path: string, body: string|null}[], close: () => Promise<void>, port: number}>}
+ */
+const startStubServer = async existingNotes => {
+    const requests = []
+
+    const server = createServer((req, res) => {
+        const url = new URL(req.url, 'http://127.0.0.1')
+        requests.push({ method: req.method, path: url.pathname, body: url.searchParams.get('body') })
+
+        const respond = payload => {
+            res.writeHead(200, { 'content-type': 'application/json' })
+            res.end(JSON.stringify(payload))
+        }
+
+        if (url.pathname === '/slack/users.list') {
+            req.resume()
+            return respond({ ok: true, members: SLACK_MEMBERS })
+        }
+
+        if (url.pathname === notesPath) {
+            req.resume()
+            if (req.method === 'GET') return respond(existingNotes)
+            return respond({ id: 'stub-note-id' })
+        }
+
+        if (url.pathname.startsWith(notesPath)) {
+            req.resume()
+            return respond({ id: 'stub-note-id' })
+        }
+
+        req.resume()
+        res.writeHead(404).end('{}')
+    })
+
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+
+    return {
+        requests,
+        port: server.address().port,
+        close: () => new Promise(resolve => server.close(resolve)),
+    }
+}
+
+/**
+ * Runs the bundled CLI against the stub server and returns what it did.
+ *
+ * @param {object} options
+ * @param {object[]} options.existingNotes notes already on the stub merge request
+ * @param {string} options.configPath path to the reviewer JSON fixture
+ */
+const runRoulette = async ({ existingNotes, configPath }) => {
+    const stub = await startStubServer(existingNotes)
+    const baseUrl = `http://127.0.0.1:${stub.port}`
+
+    try {
+        const child = spawn(process.execPath, ['dist/roulette.js'], {
+            env: {
+                ...process.env,
+                REVIEWER_CONFIG: configPath,
+                REVIEWER_BOT_USERNAME: 'roulette-bot',
+                REVIEWER_BOT_SLACK_TOKEN: 'xoxb-stub-token',
+                PROJECT_REVIEWER_BOT_PAT: 'stub-pat',
+                SLACK_API_URL: `${baseUrl}/slack/`,
+                GITLAB_API_URL: `${baseUrl}/gitlab`,
+                GITLAB_USER_ID: String(AUTHOR_USER_ID),
+                CI_PROJECT_ID: PROJECT_ID,
+                CI_MERGE_REQUEST_IID: MERGE_REQUEST_IID,
+                CI_JOB_URL: 'https://gitlab.example.com/job/1',
+                HTTPS_PROXY: '',
+            },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        })
+
+        let stdout = ''
+        let stderr = ''
+        child.stdout.on('data', chunk => (stdout += chunk))
+        child.stderr.on('data', chunk => (stderr += chunk))
+
+        const exitCode = await new Promise((resolve, reject) => {
+            child.on('error', reject)
+            child.on('close', resolve)
+            setTimeout(() => {
+                child.kill('SIGKILL')
+                reject(new Error('Timed out after 30s waiting for the CLI to exit'))
+            }, 30_000).unref()
+        })
+
+        // The CLI does not await its final write, so give the socket a tick to land.
+        await new Promise(resolve => setTimeout(resolve, 250))
+
+        return { exitCode, stdout, stderr, requests: stub.requests }
+    } finally {
+        await stub.close()
+    }
+}
+
+const failures = []
+
+/**
+ * @param {string} description what the assertion proves
+ * @param {boolean} condition
+ * @param {string} [detail] context printed when the assertion fails
+ */
+const check = (description, condition, detail = '') => {
+    if (condition) {
+        console.log(`  ok   ${description}`)
+    } else {
+        failures.push(description)
+        console.log(`  FAIL ${description}${detail ? `\n       ${detail}` : ''}`)
+    }
+}
+
+const rouletteComment = 'wheel_of_dharma: Reviewer Roulette'
+
+const main = async () => {
+    const fixtureDir = await mkdtemp(path.join(tmpdir(), 'roulette-smoke-'))
+    const configPath = path.join(fixtureDir, 'reviewers.json')
+    await writeFile(configPath, JSON.stringify(REVIEWERS))
+
+    console.log('\nposts a comment naming one eligible maintainer and one other developer')
+    {
+        const { exitCode, stdout, stderr, requests } = await runRoulette({ existingNotes: [], configPath })
+        const posted = requests.filter(r => r.method === 'POST' && r.path.startsWith(notesPath))
+
+        check('the CLI exits successfully', exitCode === 0, `exit=${exitCode}\n${stderr || stdout}`)
+        check('it creates exactly one note', posted.length === 1, `posted ${posted.length} note(s)`)
+
+        const body = posted.length === 1 ? decodeURIComponent(posted[0].body ?? '') : ''
+        check('the note is the roulette comment', body.includes(rouletteComment))
+        check('the only eligible maintainer is named', body.includes('Linus Maintainer (linus@example.com)'), body)
+        check('the remaining developer is named', body.includes('Barbara Contributor (barbara@example.com)'), body)
+        check('the merge request author is excluded', !body.includes('Ada Author'), body)
+        check('the reviewer on holiday is excluded', !body.includes('Grace Onholiday'), body)
+        check('the job URL is linked', body.includes('https://gitlab.example.com/job/1'))
+    }
+
+    console.log('\nleaves an existing comment alone when a re-roll was not requested')
+    {
+        const existing = [{ id: '99', author: { username: 'roulette-bot' }, body: `${rouletteComment}\n- [ ] Give me two new approvers` }]
+        const { exitCode, requests } = await runRoulette({ existingNotes: existing, configPath })
+        const writes = requests.filter(r => r.path.startsWith(notesPath) && (r.method === 'POST' || r.method === 'PUT'))
+
+        check('the CLI exits successfully', exitCode === 0)
+        check('it does not write to the merge request', writes.length === 0, `wrote ${writes.length} time(s)`)
+    }
+
+    console.log('\nreplaces the existing comment when a re-roll was requested')
+    {
+        const existing = [{ id: '99', author: { username: 'roulette-bot' }, body: `${rouletteComment}\n- [x] Give me two new approvers` }]
+        const { exitCode, requests } = await runRoulette({ existingNotes: existing, configPath })
+        const updates = requests.filter(r => r.method === 'PUT')
+
+        check('the CLI exits successfully', exitCode === 0)
+        check('it updates the existing note in place', updates.length === 1 && updates[0].path === `${notesPath}/99`, JSON.stringify(updates))
+    }
+
+    console.log('')
+    if (failures.length > 0) {
+        console.error(`Smoke test failed: ${failures.length} assertion(s) did not hold.`)
+        process.exit(1)
+    }
+    console.log('Smoke test passed.')
+}
+
+main().catch(error => {
+    console.error(error)
+    process.exit(1)
+})

--- a/src/roulette.ts
+++ b/src/roulette.ts
@@ -36,7 +36,10 @@ const config = {
 
 const getAllSlackUsers = async () => {
     const maybeHttpsProxy = process.env.HTTPS_PROXY
-    const clientOpts: WebClientOptions = maybeHttpsProxy ? { agent: new HttpsProxyAgent(maybeHttpsProxy) } : {}
+    const clientOpts: WebClientOptions = {
+        ...(maybeHttpsProxy ? { agent: new HttpsProxyAgent(maybeHttpsProxy) } : {}),
+        ...(process.env.SLACK_API_URL ? { slackApiUrl: process.env.SLACK_API_URL } : {}),
+    }
 
     const slackClient = new WebClient(config.slackToken, clientOpts)
     const slackListUsers: UsersListResponse = await slackClient.users.list({})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
     clean: true,
     minify: true,
     format: ["cjs"], // 👈 Node
+    // https-proxy-agent is ESM-only, so a CJS bundle cannot require() it on Node
+    // versions without require(esm). Inline it instead of leaving it external.
+    noExternal: ["https-proxy-agent"],
 });


### PR DESCRIPTION
Dependency bumps have needed a manual check before merging, because CI does not prove very much: it only type-checks. It never builds the bundle that actually gets published, and nothing ever runs the tool, so a bump can go green while breaking it at runtime.

The aim here is a Build job green enough to judge a bump on, without first running the tool against real Slack and GitLab. Merging stays manual.

**Build now also bundles and runs the CLI end to end.** `scripts/smoke-test.mjs` executes `dist/roulette.js` against stub Slack and GitLab servers on loopback — no credentials, no network — and asserts the merge request author is excluded, holiday reviewers are filtered out, one maintainer plus one other developer are named, and that the create / leave-alone / replace-on-checkbox branches for the note all behave.

To confirm that is a real gate and not decoration, breaking author-exclusion in a way that still type-checks leaves `npm run tsc` passing and fails the smoke test on exactly the two affected assertions.

**It immediately found a live bug, which the first commit fixes.** `https-proxy-agent` 9 is ESM-only and the published bundle is CommonJS, so requiring it throws `ERR_REQUIRE_ESM` before any of our code runs. Version 1.0.7 as published on npm cannot start at all on the 20.11.0 that `.node-version` pins — verified by running the packed tarball on that exact runtime. It only appears to work because newer Node supports `require(esm)`. Bundling it inline lets esbuild emit CommonJS, and the proxy path is confirmed working on both 20.11.0 and current Node from a clean production install.

Also bumps `actions/checkout` and `actions/setup-node` off v3, which was being forced onto Node 24 with deprecation warnings, and takes the Node version from `.node-version` instead of repeating it in a matrix.

### Worth knowing

- `@types/node` reaches this project only as a transitive dependency of `@slack/web-api`. That is why the TypeScript 7 bump fails with eleven "Cannot find name 'process'" errors. It should probably become a direct devDependency.
- Not fixed here: `createOrUpdateNote` never returns its `fetch`, so the comment POST is fire-and-forget. If GitLab rejects it the process still exits 0, reporting success having posted nothing.