### PR TITLE
Skip reviewers whose Slack status marks them as away

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The end-to-end flow inside `runReviewRoulette()` is the part worth understanding
 2. Load the reviewer roster from the JSON file at `REVIEWER_CONFIG`.
 3. Drop the MR author from the pool (matched by `GITLAB_USER_ID` vs each reviewer's `userId`).
 4. Apply per-reviewer `selectionChance` (`selectReviewersBasedOnChance`) — a probabilistic filter that is *bypassed entirely* if it would leave fewer than one maintainer or one contributor.
-5. Remove anyone whose Slack `status_emoji` marks them as on holiday/sick (`filterReviewersBasedOnSlackHoliday`).
+5. Remove anyone whose Slack status marks them as away (`filterReviewersWhoAreAway`).
 6. Split the survivors by role, pick a random `maintainer`, then pick a second reviewer from the whole remaining pool excluding that maintainer.
 7. Build a Markdown comment body and reconcile it with GitLab via the Notes API.
 
@@ -65,11 +65,32 @@ The JSON file at `REVIEWER_CONFIG`:
       "selectionChance": 80,
       "roles": ["maintainer", "contributor"]
     }
-  ]
+  ],
+  "awayEmojis": [":palm_tree:", ":no_entry:"]
 }
 ```
-`roles` is an array of `"maintainer"` and/or `"contributor"`. `selectionChance` is an optional 0–100 percentage; omit it to always include the reviewer. A reviewer can hold both roles.
+`roles` is an array of `"maintainer"` and/or `"contributor"`. `selectionChance` is an optional 0–100 percentage; omit it to always include the reviewer. A reviewer can hold both roles. `awayEmojis` is optional and replaces the built-in away set (see below); omit it to use the defaults.
 
-## Holiday/Sick Detection
+## Away Detection
 
-A reviewer is filtered out when their Slack profile `status_emoji` is `:palm_tree:`, `:holiday:`, `:face_with_thermometer:`, or `:hospital:`. Matching is exact-string against the Slack emoji name, so the literals in `filterReviewersBasedOnSlackHoliday` must match Slack precisely (including surrounding colons).
+A reviewer is filtered out when their Slack status uses one of the away emoji, listed in `defaultAwayEmojis` in `src/roulette.ts` and overridable per-project (see below).
+
+**The list is hardcoded because Slack offers no way to read it.** Don't spend time looking for one — this was checked against the live API, not inferred:
+- There is no `is_ooo` or away flag on the user object, and no endpoint returning a workspace's status suggestions.
+- `emoji.list` with `include_categories: true` (scope `emoji:read`) returns **only the nine Unicode groups** — `Smileys & People`, `Component`, `Animals & Nature`, `Food & Drink`, `Travel & Places`, `Activities`, `Objects`, `Symbols`, `Flags`. The emoji picker's "Out of Office" section is **not** among them; it is client-side only.
+- The Out of Office emoji do appear in that response's `emoji` map, but as ordinary workspace custom emoji among ~1,600 others, with nothing marking them as out-of-office. (They happen to share two `emoji.slack-edge.com` batch hashes, but recovering the set that way needs the names first, so it cannot bootstrap the list.)
+
+`defaultAwayEmojis` is therefore copied by hand, from three sources:
+- Slack's **Out of Office** category in full: `at-the-beach`, `catching-up`, `computer-sleep`, `out-of-office`, `pto-soon`, `relaxing`, `sleeping-potato`, `touch-grass`, `travel-time`.
+- The away members of Slack's **Hybrid Work** and **Remote Work** categories: `ooo`, `pto`, `self-care`, `away`. Deliberately partial — the rest of those categories are still-working statuses (`working-from-home`, `hot-desking`, `commuting`, `here`, `virtual-meeting`) that must not exclude anyone.
+- Statuses that predate all of it: `palm_tree`, `holiday`, `desert_island`, `face_with_thermometer`, `hospital`, `no_entry`. `no_entry` is what Slack's built-in out-of-office status sets, including when synced from Google or Outlook Calendar.
+
+If Slack changes these categories the list has to be updated to match — the smoke test pins every name, so a stale entry is at least visible.
+
+A config file may override the whole set with a top-level `awayEmojis` array; it **replaces** the defaults rather than adding to them.
+
+Two normalisation rules matter when changing this:
+- Names are compared bare, so config and profile values may be written with or without colons, and a skin-tone suffix (`:wave::skin-tone-2:`) is stripped.
+- A workspace emoji alias means `profile.status_emoji` can be a name the set does not contain while `profile.status_emoji_display_info[].emoji_name` holds the one it does, so every name Slack reports for the status is matched.
+
+The generated MR comment describes the rule rather than listing the emoji: most of the set is Slack custom emoji, which GitLab renders as literal `:name:` text.

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -38,9 +38,10 @@ const notesPath = `/gitlab/api/v4/projects/${PROJECT_ID}/merge_requests/${MERGE_
 
 /**
  * @param {object[]} existingNotes notes the stub GitLab returns from the GET
+ * @param {object[]} slackMembers members the stub Slack returns from users.list
  * @returns {Promise<{requests: {method: string, path: string, body: string|null}[], close: () => Promise<void>, port: number}>}
  */
-const startStubServer = async existingNotes => {
+const startStubServer = async (existingNotes, slackMembers) => {
     const requests = []
 
     const server = createServer((req, res) => {
@@ -54,7 +55,7 @@ const startStubServer = async existingNotes => {
 
         if (url.pathname === '/slack/users.list') {
             req.resume()
-            return respond({ ok: true, members: SLACK_MEMBERS })
+            return respond({ ok: true, members: slackMembers })
         }
 
         if (url.pathname === notesPath) {
@@ -87,9 +88,10 @@ const startStubServer = async existingNotes => {
  * @param {object} options
  * @param {object[]} options.existingNotes notes already on the stub merge request
  * @param {string} options.configPath path to the reviewer JSON fixture
+ * @param {object[]} [options.slackMembers] members the stub Slack returns from users.list
  */
-const runRoulette = async ({ existingNotes, configPath }) => {
-    const stub = await startStubServer(existingNotes)
+const runRoulette = async ({ existingNotes, configPath, slackMembers = SLACK_MEMBERS }) => {
+    const stub = await startStubServer(existingNotes, slackMembers)
     const baseUrl = `http://127.0.0.1:${stub.port}`
 
     try {
@@ -172,6 +174,96 @@ const main = async () => {
         check('the merge request author is excluded', !body.includes('Ada Author'), body)
         check('the reviewer on holiday is excluded', !body.includes('Grace Onholiday'), body)
         check('the job URL is linked', body.includes('https://gitlab.example.com/job/1'))
+        check('the comment explains the away rule', body.includes('marks them as out of office'), body)
+    }
+
+    console.log("\nexcludes reviewers using each of Slack's away emoji")
+    {
+        const awayEmojis = [
+            // "Out of Office" category
+            'at-the-beach',
+            'catching-up',
+            'computer-sleep',
+            'out-of-office',
+            'pto-soon',
+            'relaxing',
+            'sleeping-potato',
+            'touch-grass',
+            'travel-time',
+            // "Hybrid Work" and "Remote Work" categories
+            'ooo',
+            'pto',
+            'self-care',
+            'away',
+        ]
+
+        for (const emoji of awayEmojis) {
+            const slackMembers = [
+                { id: 'U_ADA', profile: { status_emoji: '' } },
+                { id: 'U_GRACE', profile: { status_emoji: `:${emoji}:` } },
+                { id: 'U_LINUS', profile: { status_emoji: ':coffee:' } },
+                { id: 'U_BARBARA', profile: { status_emoji: '' } },
+            ]
+            const { requests } = await runRoulette({ existingNotes: [], configPath, slackMembers })
+            const posted = requests.filter(r => r.method === 'POST' && r.path.startsWith(notesPath))
+            const body = posted.length === 1 ? decodeURIComponent(posted[0].body ?? '') : ''
+
+            check(`:${emoji}: excludes the reviewer`, !body.includes('Grace Onholiday') && body.includes('Linus Maintainer'), body)
+        }
+    }
+
+    console.log("\nexcludes a reviewer using Slack's own out of office status")
+    {
+        const slackMembers = [
+            { id: 'U_ADA', profile: { status_emoji: '' } },
+            { id: 'U_GRACE', profile: { status_emoji: ':no_entry:' } },
+            { id: 'U_LINUS', profile: { status_emoji: ':coffee:' } },
+            { id: 'U_BARBARA', profile: { status_emoji: '' } },
+        ]
+        const { exitCode, requests } = await runRoulette({ existingNotes: [], configPath, slackMembers })
+        const posted = requests.filter(r => r.method === 'POST' && r.path.startsWith(notesPath))
+        const body = posted.length === 1 ? decodeURIComponent(posted[0].body ?? '') : ''
+
+        check('the CLI exits successfully', exitCode === 0)
+        check('the out of office reviewer is excluded', !body.includes('Grace Onholiday'), body)
+        check('the available maintainer is named', body.includes('Linus Maintainer'), body)
+    }
+
+    console.log('\nexcludes a reviewer whose away status is a workspace emoji alias')
+    {
+        const slackMembers = [
+            { id: 'U_ADA', profile: { status_emoji: '' } },
+            {
+                id: 'U_GRACE',
+                profile: {
+                    status_emoji: ':annual-leave:',
+                    status_emoji_display_info: [{ emoji_name: 'palm_tree', display_alias: ':annual-leave:' }],
+                },
+            },
+            { id: 'U_LINUS', profile: { status_emoji: ':coffee:' } },
+            { id: 'U_BARBARA', profile: { status_emoji: '' } },
+        ]
+        const { exitCode, requests } = await runRoulette({ existingNotes: [], configPath, slackMembers })
+        const posted = requests.filter(r => r.method === 'POST' && r.path.startsWith(notesPath))
+        const body = posted.length === 1 ? decodeURIComponent(posted[0].body ?? '') : ''
+
+        check('the CLI exits successfully', exitCode === 0)
+        check('the aliased away reviewer is excluded', !body.includes('Grace Onholiday'), body)
+        check('the available maintainer is named', body.includes('Linus Maintainer'), body)
+    }
+
+    console.log('\nuses the away emojis from the reviewer config in place of the defaults')
+    {
+        const customConfigPath = path.join(fixtureDir, 'reviewers-custom-away.json')
+        await writeFile(customConfigPath, JSON.stringify({ ...REVIEWERS, awayEmojis: [':coffee:'] }))
+
+        const { exitCode, requests } = await runRoulette({ existingNotes: [], configPath: customConfigPath })
+        const posted = requests.filter(r => r.method === 'POST' && r.path.startsWith(notesPath))
+        const body = posted.length === 1 ? decodeURIComponent(posted[0].body ?? '') : ''
+
+        check('the CLI exits successfully', exitCode === 0)
+        check('the reviewer using the configured away emoji is excluded', !body.includes('Linus Maintainer'), body)
+        check('a default away emoji no longer excludes anyone', body.includes('Grace Onholiday'), body)
     }
 
     console.log('\nleaves an existing comment alone when a re-roll was not requested')

--- a/src/roulette.ts
+++ b/src/roulette.ts
@@ -24,7 +24,57 @@ type Reviewer = {
 
 type ReviewerData = {
     reviewers: Reviewer[]
+    awayEmojis?: string[]
 }
+
+// Slack's own "Out of Office" emoji category, as the client shows it. It has to be copied here:
+// `emoji.list?include_categories=true` returns only the nine Unicode groups, and these arrive as
+// ordinary workspace custom emoji, so nothing in the API distinguishes them from any other.
+const slackOutOfOfficeEmojis = [
+    'at-the-beach',
+    'catching-up',
+    'computer-sleep',
+    'out-of-office',
+    'pto-soon',
+    'relaxing',
+    'sleeping-potato',
+    'touch-grass',
+    'travel-time',
+]
+
+// Away statuses from Slack's "Hybrid Work" and "Remote Work" categories. Both categories are mostly
+// still-working statuses (`working-from-home`, `hot-desking`, `here`), so only these four count.
+const slackAwayWorkEmojis = ['ooo', 'pto', 'self-care', 'away']
+
+// Statuses that predate the categories and are still in use. `:no_entry:` is what Slack's built-in
+// out-of-office status sets, including when it is synced from Google or Outlook Calendar.
+const defaultAwayEmojis = [
+    ...slackOutOfOfficeEmojis,
+    ...slackAwayWorkEmojis,
+    'palm_tree',
+    'holiday',
+    'desert_island',
+    'face_with_thermometer',
+    'hospital',
+    'no_entry',
+]
+
+// Slack accepts a status emoji with or without colons, and appends a skin tone as a second
+// `::`-delimited name, so both config and profile values are reduced to a bare name before matching.
+const normaliseEmojiName = (emoji: string) => emoji.trim().toLowerCase().replace(/^:|:$/g, '').split('::')[0]
+
+// A workspace alias resolves to a different name than the one on the profile, so every name Slack
+// reports for the status counts as a candidate.
+const emojiNamesForStatus = (slackUser: Member) =>
+    [
+        slackUser.profile?.status_emoji,
+        ...(slackUser.profile?.status_emoji_display_info ?? []).flatMap(info => [
+            info.emoji_name,
+            info.display_alias,
+        ]),
+    ]
+        .filter((name): name is string => !!name)
+        .map(normaliseEmojiName)
 
 // Config
 const config = {
@@ -47,33 +97,27 @@ const getAllSlackUsers = async () => {
     return slackListUsers.members!
 }
 
-const filterReviewersBasedOnSlackHoliday = (reviewers: Reviewer[], slackUsers: Member[]) => {
+const filterReviewersWhoAreAway = (reviewers: Reviewer[], slackUsers: Member[], awayEmojis: Set<string>) => {
     const slackUsersFilteredToReviewers = slackUsers.filter(slackUser => {
         return slackUser.id && reviewers.map(reviewer => reviewer.slackUserId).includes(slackUser.id)
     })
 
-    const slackUserIdsOnHolidayOrSick = slackUsersFilteredToReviewers
-        .filter(
-            slackUser =>
-                slackUser.profile?.status_emoji == ':palm_tree:' ||
-                slackUser.profile?.status_emoji == ':holiday:' ||
-                slackUser.profile?.status_emoji == ':face_with_thermometer:' ||
-                slackUser.profile?.status_emoji == ':hospital:'
-        )
+    const slackUserIdsWhoAreAway = slackUsersFilteredToReviewers
+        .filter(slackUser => emojiNamesForStatus(slackUser).some(name => awayEmojis.has(name)))
         .map(slackUser => slackUser.id)
 
-    // Remove anyone with the holiday emoji in Slack
-    const reviewersWithoutAuthorAndPeopleOnHoliday = reviewers.filter(
-        reviewer => !slackUserIdsOnHolidayOrSick.includes(reviewer.slackUserId)
+    // Remove anyone whose Slack status marks them as away
+    const reviewersWithoutAuthorAndPeopleAway = reviewers.filter(
+        reviewer => !slackUserIdsWhoAreAway.includes(reviewer.slackUserId)
     )
 
     console.log(
-        `Eligible reviewers after removing holiday/sick, author and filtering by chance: ${JSON.stringify(
-            reviewersWithoutAuthorAndPeopleOnHoliday.map(reviewer => reviewer.name)
+        `Eligible reviewers after removing away, author and filtering by chance: ${JSON.stringify(
+            reviewersWithoutAuthorAndPeopleAway.map(reviewer => reviewer.name)
         )}`
     )
 
-    return reviewersWithoutAuthorAndPeopleOnHoliday
+    return reviewersWithoutAuthorAndPeopleAway
 }
 
 const selectReviewersBasedOnChance = (reviewers: Reviewer[]) => {
@@ -124,15 +168,20 @@ const runReviewRoulette = async () => {
 
     const reviewersSelectedBasedOnChance = selectReviewersBasedOnChance(reviewersWithoutAuthor)
 
-    const reviewersWithoutAuthorAndPeopleOnHoliday = filterReviewersBasedOnSlackHoliday(
+    const awayEmojis = new Set((reviewerData.awayEmojis ?? defaultAwayEmojis).map(normaliseEmojiName))
+
+    console.log(`Away emojis: ${JSON.stringify([...awayEmojis])}`)
+
+    const reviewersWithoutAuthorAndPeopleAway = filterReviewersWhoAreAway(
         reviewersSelectedBasedOnChance,
-        slackMembers
+        slackMembers,
+        awayEmojis
     )
 
     // Don't include the pipeline/MR creator in the list of possible reviewers
-    const maintainers = reviewersWithoutAuthorAndPeopleOnHoliday.filter(item => item.roles.includes('maintainer'))
+    const maintainers = reviewersWithoutAuthorAndPeopleAway.filter(item => item.roles.includes('maintainer'))
 
-    const allDevelopers = reviewersWithoutAuthorAndPeopleOnHoliday
+    const allDevelopers = reviewersWithoutAuthorAndPeopleAway
 
     const randomMaintainer = getRandomReviewer(maintainers)
 
@@ -142,12 +191,17 @@ const runReviewRoulette = async () => {
     console.log(`Rand Maintainer = ${JSON.stringify(randomMaintainer)}`)
     console.log(`Rand All Dev = ${JSON.stringify(randomAllDeveloper)}`)
 
+    // The away set is mostly Slack custom emoji, which GitLab renders as literal `:name:` text, so
+    // the comment describes the rule rather than listing them.
+    const awayEmojiSentence =
+        awayEmojis.size > 0 ? ' (the bot skips anyone whose Slack status marks them as out of office)' : ''
+
     const gitlabCommentBody = `
 ## :wheel_of_dharma: Reviewer Roulette
 
 To spread load more evenly across eligible reviewers and to enable speedy review the Roulette Bot has randomly selected two reviewers for this MR.
 
-You can make different choices if you think someone else would be better-suited or if someone is on holiday (the bot checks for the :palm_tree:, :face_with_thermometer: and :hospital: emojis on Slack). Other people are free to review if they'd like to as well. 
+You can make different choices if you think someone else would be better-suited or if someone is away${awayEmojiSentence}. Other people are free to review if they'd like to as well.
 
 Once you've decided who will review this merge request **please assign them as a reviewer!** Roulette Bot does not do this automatically.
 


### PR DESCRIPTION
## What

Reviewer selection now skips anyone whose Slack status uses an away emoji from Slack's **Out of Office** category in full, plus the away members of **Hybrid Work** and **Remote Work** (`:ooo:`, `:pto:`, `:self-care:`, `:away:`). The previous four emoji are kept, and `:no_entry:` is added for Slack's built-in out-of-office status, which is also what Google/Outlook calendar sync sets.

Away emoji can now be overridden per project with a top-level `awayEmojis` array in the reviewer config file, replacing the defaults.

## Why

Slack has added these categories since the bot was written, and people use them. Anyone marked away with one of the newer emoji was still being selected as a reviewer — which is the one thing the check exists to prevent.

A second, quieter version of the same bug: someone using a **workspace emoji alias** was also still being selected. Slack puts the alias name on the profile, so comparing that name alone never matched, no matter which emoji the alias pointed at. Matching now considers every name Slack reports for the status.

The `awayEmojis` override exists because teams do not all share one convention, and adding to a hardcoded list needed a release.

## Notes for review

**The list is hardcoded, and it has to be.** Slack exposes no way to read these categories — verified against the live API rather than inferred:

- `emoji.list` with `include_categories: true` returns only the nine Unicode groups. The picker's Out of Office / Hybrid Work / Remote Work sections are client-side only.
- The emoji do appear in that response's `emoji` map, but as ordinary workspace custom emoji among ~1,600, with nothing marking them as away.
- There is no `is_ooo` or away flag on the user object, and no endpoint returning a workspace's status suggestions.

I built the API-driven version first and removed it once this came back negative, rather than leave a call that can never succeed plus a scope to provision. **The bot token needs no new scopes.** `CLAUDE.md` records the finding so nobody repeats the investigation.

The Hybrid Work and Remote Work picks are deliberately partial — the rest of those categories (`working-from-home`, `hot-desking`, `commuting`, `here`, `virtual-meeting`) mean working, just not at a desk, and must not exclude anyone. `:afk:` was considered and deliberately left out.

**The comment no longer lists the emoji it skips.** At ~19 entries, mostly Slack custom emoji that GitLab renders as literal `:sleeping-potato:` text, the list was doing more harm than good; it now describes the rule instead.

## Verification

`npm run tsc` and `npm run smoke` both clean — 32 smoke assertions, up from 12. New coverage pins every away emoji individually, plus alias resolution, Slack's built-in OOO status, and the config override with a negative control that a default stops excluding once overridden.

Every new assertion was confirmed to fail against the pre-change code before being kept.

Worth knowing for future dependency bumps: `tsup` does not type-check, so `npm run smoke` passed on an `.at(-1)` that `tsc` rejected against the ES2016 lib target. Both are needed.
