### PR TITLE
Publish to npm from a GitHub Release

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -7,8 +7,10 @@ name: Build
 on:
   push:
     branches: [ "main" ]
+  # Every pull request, not only those targeting main, so that one stacked on
+  # another is checked too. Leaving push filtered to main keeps that to one run
+  # per commit rather than two.
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,54 @@
+# Publishes @createiq/reviewer-roulette when a GitHub Release is published.
+# Authentication is npm trusted publishing over OIDC, so there is no npm token
+# in this repository's secrets; the package's trusted publisher on npmjs.com
+# must name this workflow file.
+
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # npm trusted publishing exchanges this for a short-lived token
+
+concurrency:
+  group: publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install the toolchain from mise.toml
+        uses: jdx/mise-action@v4
+      # Only for the registry it writes into .npmrc — the Node on PATH is mise's.
+      - uses: actions/setup-node@v7
+        with:
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+
+      - name: Check the tag matches the version being published
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="$(node -p 'require("./package.json").version')"
+          if [ "${TAG#v}" != "$version" ]; then
+            echo "Release tag $TAG does not name package.json version $version." >&2
+            echo "Bump the version on main and recreate the release." >&2
+            exit 1
+          fi
+
+      - name: Type-check
+        run: npm run tsc
+      # Bundles, then drives dist/roulette.js against stub Slack and GitLab
+      # servers. The bundle it proves is the one npm publish then uploads.
+      - name: Smoke test
+        run: npm run smoke
+
+      - name: Publish
+        run: npm publish --provenance --access public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,15 @@ External integrations are the Slack Web API (`@slack/web-api`) for status/holida
 
 - `npm run build` / `npm run tsc` — runs `tsc -p tsconfig.json`. This is a pure **type-check**: `tsconfig.json` sets `noEmit`, so it produces no output files (leave it that way — without it, `tsc` sprays compiled JS next to the source, and nothing here is gitignored except `dist`). It is *not* what gets published.
 - `npm run bundle` — runs `tsup`, producing the real artifact: a minified CommonJS bundle at `dist/roulette.js`. This is what `bin`/`main` point to and what consumers actually execute.
-- `npm run upload` — bundles then `npm publish --access public`. Requires npm auth. Bump `version` in `package.json` first (see `PUBLISHING.md`).
+- `npm run upload` — bundles then `npm publish --access public`. Requires npm auth. This is the break-glass path only: releases normally go out from `.github/workflows/publish-npm.yml` (see `PUBLISHING.md`).
 
 - `npm run smoke` — bundles, then runs `scripts/smoke-test.mjs`: it executes `dist/roulette.js` against stub Slack and GitLab servers on loopback and asserts on the comment it posts (author excluded, holiday reviewers excluded, one maintainer plus one other developer named) and on the create/no-op/replace behaviour for an existing note. No credentials or network access needed. Because it drives the bundle over real HTTP, it catches runtime breakage from dependency bumps that `tsc` passes clean.
 
 There is **no unit-test framework and no linter** configured — don't go looking for one or assume a `test`/`lint` script exists. Verification before publishing is `npm run tsc` (type-check) plus `npm run smoke`. CI (`.github/workflows/build-node.yml`) runs all three on the Node version in `mise.toml` (currently 24), installed there by `mise-action` so the version is declared in one place only.
 
 Merging to `main` needs a pull request with a passing `build` check and one approving review, all enforced by repository rulesets. Dependency bumps are merged by hand; the point of the smoke test is that a green Build is enough to judge one on, without running the tool against real Slack and GitLab first.
+
+Publishing to npm is done by `.github/workflows/publish-npm.yml`, triggered by publishing a GitHub Release. It re-runs the type-check and smoke test, refuses to publish if the release tag does not name the version in `package.json`, and authenticates over OIDC rather than a stored npm token — so the package's trusted publisher on npmjs.com has to name that workflow file.
 
 ## Runtime Configuration (environment variables)
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,4 +1,23 @@
-# Publishing a new package
+# Publishing a new version
 
-1. Bump the version in package.json
-2. `npm run upload` - authenticate with your npm credentials
+Publishing is done by GitHub Actions, from a published GitHub Release.
+
+1. Raise a pull request bumping `version` in `package.json`, and merge it once
+   Build is green.
+2. Draft a new release at
+   <https://github.com/linklaterscreateiq/reviewer-roulette/releases/new>,
+   creating a tag that names the new version (`1.0.8`, matching the existing
+   tags) against `main`, and publish it.
+3. The `Publish` workflow type-checks, runs the smoke test against the bundle it
+   is about to upload, and publishes it. It refuses to publish if the tag does
+   not name the version in `package.json`.
+
+No npm token is stored in this repository. The workflow authenticates with npm
+over OIDC, which requires `.github/workflows/publish-npm.yml` to be registered
+as the package's trusted publisher in its settings on npmjs.com. A side effect
+is that published versions carry a provenance attestation linking them to the
+commit and workflow run that built them.
+
+`npm run upload` still publishes from a developer machine with npm credentials.
+It skips every check above and produces a release with no provenance, so use it
+only if the workflow itself is broken.


### PR DESCRIPTION
Publishing is a manual `npm run upload` from whichever machine happens to have npm credentials. Nothing ties a published version to a commit, nothing stops a tarball going out from a dirty or unreviewed tree, and the tag on GitHub can say anything at all — 1.0.6 and 1.0.7 are on npm with no release or tag behind them.

Publishing a GitHub Release now does it instead. The workflow re-runs the type-check and the smoke test against the very bundle it uploads, and refuses to publish when the release tag does not name the version in `package.json`.

It authenticates over OIDC rather than a stored npm token, so there is no long-lived credential in this repository and published versions carry a provenance attestation. The package's trusted publisher on npmjs.com has been pointed at `.github/workflows/publish-npm.yml`.

`npm run upload` is kept as a break-glass path for when the workflow itself is broken.

### Build now runs on every pull request

`build`'s `pull_request` filter matched on the *base* branch, so a pull request stacked on another got no CI whatsoever — it looked green because nothing had run. This one was in exactly that position. `push` stays filtered to `main`, so it is still one build per commit rather than two.

### Stacked on #11

Based on `chore/node-24-mise`, not `main`, and should merge after it. The publish job needs npm ≥ 11.5.1 for trusted publishing; `main`'s `.node-version` of 20.11.0 ships npm 10.2.4, which cannot do it. Taking the Node 24 from `mise.toml` also keeps the version declared in one place, so there is no second copy here.