### PR TITLE
Release 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@createiq/reviewer-roulette",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@createiq/reviewer-roulette",
-      "version": "1.0.7",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "8.0.0",
@@ -21,6 +21,9 @@
         "tsdown": "0.22.14",
         "typescript": "7.0.2",
         "vitest": "4.1.10"
+      },
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@biomejs/biome": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@createiq/reviewer-roulette",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Randomly select reviewers for your merge request from a configuration file with Slack integration for holiday detection",
   "main": "./dist/roulette.js",
   "bin": {
@@ -32,5 +32,8 @@
     "tsdown": "0.22.14",
     "typescript": "7.0.2",
     "vitest": "4.1.10"
+  },
+  "engines": {
+    "node": ">=22.19.0"
   }
 }


### PR DESCRIPTION
Bumps `version` to 1.1.0 so a GitHub Release tagged `1.1.0` can publish it. Nothing else changes except `engines`, explained below.

Once this merges, draft a release at [releases/new](https://github.com/linklaterscreateiq/reviewer-roulette/releases/new) with tag `1.1.0` against `main` and publish it. `publish-npm.yml` does the rest, and refuses to publish if the tag does not name the version here — verified: `1.1.0` and `v1.1.0` accepted, `1.1.1` rejected.

npm still has 1.0.7; 1.0.6 and 1.0.7 were hand-published with no tag or release behind them, so this is the first release to go out through the workflow, with provenance.

### Two behaviour changes for anyone upgrading

**A run that cannot post its comment now fails.** Previously the GitLab write was neither awaited nor status-checked, so a 401/403/404 exited 0 having requested no reviewers. Separately, a missing required environment variable left the bot unable to recognise its own comment, so it posted a **duplicate on every pipeline run** — also exit 0. Both now exit non-zero naming the cause.

Worth flagging because it is visible: a pipeline that was quietly broken will start reporting it rather than passing.

**The runtime floor has risen.** undici 8 needs Node >= 22.19.0, so `package.json` now declares `engines.node`. Without it, an install on Node 20 resolves happily and fails at run time. This is the one change here beyond the version number.

That raised floor is arguably a major rather than a minor. I have gone with 1.1.0 as asked; say the word if you would rather it were 2.0.0.

### What is in it, since 1.0.5

- Reviewers whose Slack status marks them out of office are skipped, covering Slack's full "Out of Office" category plus the away members of "Hybrid Work" and "Remote Work".
- Failures are loud: missing environment variables and rejected GitLab writes both exit non-zero.
- Node 24 (declared once, in `mise.toml`), TypeScript 7, `@slack/web-api` 8, undici 8 in place of `https-proxy-agent`.
- Publishing runs from a GitHub Release over OIDC with provenance, instead of `npm run upload` from a laptop.
- Biome lints and formats, failing on warnings; the end-to-end suite runs under Vitest; tsdown replaces tsup.

### Verification on this branch

`npm run lint`, `npm run tsc`, 22/22 Vitest assertions, and `scripts/proxy-check.mjs` all pass. `npm pack --dry-run` produces `createiq-reviewer-roulette-1.1.0.tgz` containing `dist/roulette.js`.