### PR TITLE
Declare the repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,14 @@
   "keywords": [],
   "author": "Linklaters CreateiQ",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/linklaterscreateiq/reviewer-roulette.git"
+  },
+  "bugs": {
+    "url": "https://github.com/linklaterscreateiq/reviewer-roulette/issues"
+  },
+  "homepage": "https://github.com/linklaterscreateiq/reviewer-roulette#readme",
   "dependencies": {
     "@slack/web-api": "8.0.0",
     "undici": "8.10.0"


### PR DESCRIPTION
The 1.1.0 release failed at the `Publish` step. npm's registry validates a
provenance attestation against `package.json`, and refused the upload:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@createiq%2freviewer-roulette
- Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "", expected to match
  "https://github.com/linklaterscreateiq/reviewer-roulette" from provenance
```

The package has never declared `repository`, which did not matter while
releases went out by hand without provenance. `--provenance` makes it
mandatory. `bugs` and `homepage` come along with it so the npm page links
back to the repository.

1.1.0 was not published — the registry rejected it after signing — so the
same version can go out again once this is on `main` and the tag is moved
onto it.